### PR TITLE
Enable detecting iOS 13 on iPad

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,9 @@
 
 var navigator = require('global/window').navigator
 
-module.exports = (function detect_iOS (userAgent) {
-  return /iPad|iPhone|iPod/.test(userAgent)
-})(navigator ? navigator.userAgent : '')
+module.exports = (function detect_iOS (navigator) {
+  return (
+    /iPad|iPhone|iPod/.test(navigator.userAgent || '') ||
+    (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1) // iPad iOS 13
+  )
+})(navigator || {})


### PR DESCRIPTION
This PR adds ability to detect iOS 13 on iPad.