### PR TITLE
Package TypeScript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "tape": "^5.0.1"
   },
   "files": [
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ],
   "dependencies": {
     "global": "~4.4.0"


### PR DESCRIPTION
At the moment, types from `index.d.ts` are not available for consumers of `is-ios`, as `index.d.ts` is only referenced in `package.json`, not packed and published to the npm registry.

Are The Types Wrong reports that the package "has no types": https://arethetypeswrong.github.io/?p=is-ios%402.1.0.

Before:

```
This package does not contain types.
Details:  { packageName: 'is-ios', packageVersion: '2.1.0', types: false }
```

After:

```
No problems found 🌟


┌───────────────────┬──────────┐
│                   │ "is-ios" │
├───────────────────┼──────────┤
│ node10            │ 🟢       │
├───────────────────┼──────────┤
│ node16 (from CJS) │ 🟢 (CJS) │
├───────────────────┼──────────┤
│ node16 (from ESM) │ 🟢 (CJS) │
├───────────────────┼──────────┤
│ bundler           │ 🟢       │
└───────────────────┴──────────┘
```

If it's of any interest, I can create a second PR that adds an action that checks ATTW on every PR: https://github.com/boyum/attw-action